### PR TITLE
Backfill worklog with public project history (2024–2026)

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -103,10 +103,6 @@ export const SITE_FOOTER_ITEMS = [
     url: '/uses',
   },
   {
-    text: 'Notes',
-    url: '/notes',
-  },
-  {
     text: 'Lab',
     url: 'https://lab.zander.wtf',
     external: true,

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -107,10 +107,6 @@ export const SITE_FOOTER_ITEMS = [
     url: '/notes',
   },
   {
-    text: 'Tools',
-    url: '/tools',
-  },
-  {
     text: 'Lab',
     url: 'https://lab.zander.wtf',
     external: true,

--- a/src/content/worklog/2024-12-08-tinsel-trader.md
+++ b/src/content/worklog/2024-12-08-tinsel-trader.md
@@ -1,0 +1,6 @@
+---
+title: Tinsel Trader
+date: 2024-12-08
+---
+
+With Christmas approaching I threw together [Tinsel Trader](https://github.com/mrmartineau/tinsel-trader), a little Secret Santa organiser. It's a React app built using [bolt.new](https://bolt.new), MongoDB Atlas and me.. It was a good excuse to see how far the AI app builders had come, and how much hand-holding they still needed.

--- a/src/content/worklog/2024-12-08-tinsel-trader.md
+++ b/src/content/worklog/2024-12-08-tinsel-trader.md
@@ -1,6 +1,0 @@
----
-title: Tinsel Trader
-date: 2024-12-08
----
-
-With Christmas approaching I threw together [Tinsel Trader](https://github.com/mrmartineau/tinsel-trader), a little Secret Santa organiser. It's a React app built using [bolt.new](https://bolt.new), MongoDB Atlas and me.. It was a good excuse to see how far the AI app builders had come, and how much hand-holding they still needed.

--- a/src/content/worklog/2025-03-30-my-api-tools.md
+++ b/src/content/worklog/2025-03-30-my-api-tools.md
@@ -1,0 +1,6 @@
+---
+title: my-api-tools
+date: 2025-03-30
+---
+
+I started [my-api-tools](https://github.com/mrmartineau/my-api-tools), a growing collection of small APIs for my personal projects. Rather than spinning up a new worker every time I need an endpoint, I'm consolidating them into one place. It's the kind of personal infrastructure that quietly powers a bunch of the other things on this site.

--- a/src/content/worklog/2026-01-26-code-notes-on-site.md
+++ b/src/content/worklog/2026-01-26-code-notes-on-site.md
@@ -1,0 +1,8 @@
+---
+title: Code notes come to the site
+date: 2026-01-26
+---
+
+I finally pulled my code notes into this site. They used to live on a separate [11ty site at notes.zander.wtf](https://github.com/mrmartineau/notes.zander.wtf), but now they're a proper [content collection](/notes) here — 190-odd TILs and snippets, the oldest going all the way back to 2020.
+
+They're fully searchable too: I wired up [Algolia](https://www.algolia.com) full-text search over the lot, which took a fair bit of debugging to get right. One less site to maintain, and everything in one place.

--- a/src/content/worklog/2026-02-04-url-merge.md
+++ b/src/content/worklog/2026-02-04-url-merge.md
@@ -1,0 +1,6 @@
+---
+title: url-merge
+date: 2026-02-04
+---
+
+Published [url-merge](https://github.com/mrmartineau/url-merge), a zero-dependency URL path joiner. It's like `path.join()` but for URLs, so you don't end up with double slashes or missing ones when you stitch paths together. A tiny thing, but I was tired of reaching for the same helper in every project.

--- a/src/content/worklog/2026-02-25-vite-plugin-atlas.md
+++ b/src/content/worklog/2026-02-25-vite-plugin-atlas.md
@@ -1,0 +1,6 @@
+---
+title: vite-plugin-atlas
+date: 2026-02-25
+---
+
+Built [vite-plugin-atlas](https://github.com/mrmartineau/vite-plugin-atlas), a convention-driven component documentation plugin for Vite + React. The idea is zero configuration — drop your components in and get docs out, no Storybook-style boilerplate. I also made a point of keeping it AI-agent friendly so tools can discover and understand the components too.

--- a/src/content/worklog/2026-02-26-zed-surround.md
+++ b/src/content/worklog/2026-02-26-zed-surround.md
@@ -1,0 +1,6 @@
+---
+title: zed-surround
+date: 2026-02-26
+---
+
+I've been using [Zed](https://zed.dev) more and more, and one thing I really missed from VS Code was being able to wrap a selection in a snippet. So I built [zed-surround](https://github.com/mrmartineau/zed-surround), a Zed extension that lets you surround selected text with code snippets — directly inspired by [vscode-surround](https://github.com/yatki/vscode-surround).

--- a/src/content/worklog/2026-02-27-strifx.md
+++ b/src/content/worklog/2026-02-27-strifx.md
@@ -1,0 +1,6 @@
+---
+title: strifx
+date: 2026-02-27
+---
+
+Released [strifx](https://github.com/mrmartineau/strifx) — like [clsx](https://github.com/lukeed/clsx) but for strings. `clsx` is perfect for conditionally composing `className`s, but I kept wanting the same ergonomics for *any* string, not just classes. So now I have it.

--- a/src/content/worklog/2026-03-11-xtractr.md
+++ b/src/content/worklog/2026-03-11-xtractr.md
@@ -1,0 +1,8 @@
+---
+title: xtractr
+date: 2026-03-11
+---
+
+Back in 2023 I built a [Cloudflare Workers page scraper](https://github.com/mrmartineau/cloudflare-worker-scraper). [xtractr](https://github.com/mrmartineau/xtractr) is the proper, grown-up version of that idea: extract clean, structured content from web pages with automatic short-link expansion and lightweight page-type detection.
+
+It follows redirect chains, expands shortened links, and converts page content to clean Markdown with normalised metadata. It uses [defuddle](https://github.com/kepano/defuddle) to pull out the readable content, and detects content types via Open Graph tags, JSON-LD or domain-based heuristics. It's built for Cloudflare Workers but works in any runtime with `fetch`. This now powers the scraping in Otter.

--- a/src/content/worklog/2026-03-18-zui.md
+++ b/src/content/worklog/2026-03-18-zui.md
@@ -1,5 +1,5 @@
 ---
-title: ZUI (Zooey)
+title: Launched ZUI (Zooey)
 date: 2026-03-18
 ---
 

--- a/src/content/worklog/2026-03-18-zui.md
+++ b/src/content/worklog/2026-03-18-zui.md
@@ -1,0 +1,8 @@
+---
+title: ZUI (Zooey)
+date: 2026-03-18
+---
+
+I started [ZUI](https://github.com/mrmartineau/zui) (Zooey), a CSS-first UI library with optional React, Astro, Solid, Svelte and Vue components. The core is just CSS with design tokens and a layered architecture — no build step required — and the framework components are thin wrappers on top for when you want them.
+
+I've wanted a UI foundation of my own for a long time, one that isn't tied to a single framework and that I can drop into anything. This is me finally building it.

--- a/src/content/worklog/2026-04-27-uk-primary-school-maths.md
+++ b/src/content/worklog/2026-04-27-uk-primary-school-maths.md
@@ -1,0 +1,6 @@
+---
+title: UK Primary School Maths
+date: 2026-04-27
+---
+
+Made [uk-primary-school-maths](https://github.com/mrmartineau/uk-primary-school-maths), a little learning site to explore key maths concepts year by year. It explains the ideas behind each topic and lets you practise with checkable activities. A nice change of pace from the usual dev tooling, and genuinely useful around the house.

--- a/src/content/worklog/2026-05-06-otter-web-v1.md
+++ b/src/content/worklog/2026-05-06-otter-web-v1.md
@@ -1,0 +1,8 @@
+---
+title: Otter web v1.0.0
+date: 2026-05-06
+---
+
+[<img src="https://raw.githubusercontent.com/mrmartineau/Otter/main/public/otter-logo.svg" width="30" height="30" class="mx-2 inline border-none" /> Otter](https://github.com/mrmartineau/Otter) reached its [`otter-web-v1.0.0`](https://github.com/mrmartineau/Otter/releases) milestone. The headline features are AI-generated summaries for articles and a companion Raycast extension for saving and searching bookmarks without leaving the keyboard.
+
+Quick follow-ups landed straight after with `v1.0.1` (endpoint and AI model improvements) and `v1.1.0` (shareable tag and collection views).

--- a/src/content/worklog/2026-05-06-otter-web-v1.md
+++ b/src/content/worklog/2026-05-06-otter-web-v1.md
@@ -3,6 +3,8 @@ title: Otter web v1.0.0
 date: 2026-05-06
 ---
 
-[<img src="https://raw.githubusercontent.com/mrmartineau/Otter/main/public/otter-logo.svg" width="30" height="30" class="mx-2 inline border-none" /> Otter](https://github.com/mrmartineau/Otter) reached its [`otter-web-v1.0.0`](https://github.com/mrmartineau/Otter/releases) milestone. The headline features are AI-generated summaries for articles and a companion Raycast extension for saving and searching bookmarks without leaving the keyboard.
+[Otter](https://github.com/mrmartineau/Otter) reached its [`otter-web-v1.0.0`](https://github.com/mrmartineau/Otter/releases) milestone. I migrated from Supabase to a [better-auth](https://www.better-auth.com) / [Drizzle ORM](https://orm.drizzle.team) combo instead. The db is hosted with [Neon](https://neon.tech) which gives me a lot more flexibility to work on a greater number of side-projects.
 
-Quick follow-ups landed straight after with `v1.0.1` (endpoint and AI model improvements) and `v1.1.0` (shareable tag and collection views).
+The headline features are AI-generated summaries for articles and a companion Raycast extension for saving and searching bookmarks without leaving the keyboard.
+
+A quick follow-up landed straight after with `v1.0.1` (endpoint and AI model improvements).

--- a/src/content/worklog/2026-05-07-zed-stack-starter.md
+++ b/src/content/worklog/2026-05-07-zed-stack-starter.md
@@ -1,0 +1,6 @@
+---
+title: zed-stack-starter
+date: 2026-05-07
+---
+
+Put together [zed-stack-starter](https://github.com/mrmartineau/zed-stack-starter), a modern full-stack React starter so I can stop reassembling the same pieces every time I start something new. It's React 19 with [TanStack Router](https://tanstack.com/router), a [Hono](https://hono.dev) API, [better-auth](https://www.better-auth.com), [Drizzle ORM](https://orm.drizzle.team) on Postgres, and [ZUI](https://github.com/mrmartineau/zui) for the UI — all deployed to Cloudflare Workers.

--- a/src/content/worklog/2026-05-19-lab-zander-wtf.md
+++ b/src/content/worklog/2026-05-19-lab-zander-wtf.md
@@ -1,0 +1,10 @@
+---
+title: Launched lab.zander.wtf
+date: 2026-05-19
+---
+
+Spun up [lab.zander.wtf](https://lab.zander.wtf), a home for experiments, little tools and demos. Built with Astro and styled with [ZUI](https://github.com/mrmartineau/zui), each item gets its own page with a bespoke design.
+
+To kick it off I rescued a bunch of old experiments from my ancient `lab.martineau.tv` site and migrated them across — CSS-only icons, pure-CSS media player controls, a cloze test generator and more, some dating back to 2009.
+
+The new headline addition is the [Data Transformation Dojo](https://lab.zander.wtf/data-transformation): an interactive React trainer for reshaping data in JavaScript, with 20 real-world map/filter/reduce challenges, hints and a live test runner.

--- a/src/content/worklog/2026-05-19-otter-web-v1.1.0.md
+++ b/src/content/worklog/2026-05-19-otter-web-v1.1.0.md
@@ -1,0 +1,8 @@
+---
+title: Otter web v1.1.0
+date: 2026-05-19
+---
+
+[Otter](https://github.com/mrmartineau/Otter) shipped [`otter-web-v1.1.0`](https://github.com/mrmartineau/Otter/releases/tag/%40mrmartineau%2Fotter-web-v1.1.0). The headline addition is shareable tag and collection views, so you can hand someone a link to a curated set of bookmarks. It also fixes stale feed data and a broken trash button.
+
+Here's my [app:mac](https://otter.zander.wtf/share/bc7e75e26a7b4c30a1516c256fd58378) tag view in action.

--- a/src/content/worklog/2026-05-19-otter-web-v1.1.0.md
+++ b/src/content/worklog/2026-05-19-otter-web-v1.1.0.md
@@ -5,4 +5,4 @@ date: 2026-05-19
 
 [Otter](https://github.com/mrmartineau/Otter) shipped [`otter-web-v1.1.0`](https://github.com/mrmartineau/Otter/releases/tag/%40mrmartineau%2Fotter-web-v1.1.0). The headline addition is shareable tag and collection views, so you can hand someone a link to a curated set of bookmarks. It also fixes stale feed data and a broken trash button.
 
-Here's my [app:mac](https://otter.zander.wtf/share/bc7e75e26a7b4c30a1516c256fd58378) tag view in action.
+As an example, here's my [app:mac](https://otter.zander.wtf/share/bc7e75e26a7b4c30a1516c256fd58378) tag view in action.

--- a/src/content/worklog/2026-06-03-reps.md
+++ b/src/content/worklog/2026-06-03-reps.md
@@ -1,0 +1,8 @@
+---
+title: Reps
+date: 2026-06-03
+---
+
+Built [Reps](https://github.com/mrmartineau/reps.zander.wtf) — a daily JavaScript puzzle for your coding muscles. Think Wordle, but you write a small JavaScript function and it runs against three tests right in your browser.
+
+There are 40 puzzles covering algorithms and data transformations, with difficulty labels, an animated test runner and stat tracking. It uses the [Monaco](https://github.com/microsoft/monaco-editor) editor, runs your code in a Web Worker with timeout protection (so an infinite loop won't take the tab down with it), keeps progress in `localStorage`, and has Wordle-style spoiler-free sharing. Built with Vite and [ZUI](https://github.com/mrmartineau/zui), deployed to Cloudflare Workers.

--- a/src/content/worklog/2026-06-03-reps.md
+++ b/src/content/worklog/2026-06-03-reps.md
@@ -1,5 +1,5 @@
 ---
-title: Reps
+title: Launched Reps
 date: 2026-06-03
 ---
 

--- a/src/content/worklog/2026-06-08-projects-page.md
+++ b/src/content/worklog/2026-06-08-projects-page.md
@@ -1,0 +1,6 @@
+---
+title: Add a projects page
+date: 2026-06-08
+---
+
+Added a [projects](/projects) section to the site — side-projects, packages and other things I've made or am making. It pulls everything together in one place, from older work like [Kickoff](/projects/kickoff) and [Design System Utils](/projects/design-system-utils) through to the recent run of tools like [Otter](/projects/otter), [ZUI](/projects/zui) and [xtractr](/projects/xtractr). I also surfaced a few of them on the homepage while I was at it.


### PR DESCRIPTION
## Summary

The worklog stopped at **May 2024** (`2024-05-31-now-page`), but there are two years of public project activity on GitHub since then. This PR backfills **12 curated worklog entries** for the standout public projects and releases in that gap, written in the existing worklog voice and grounded in real repo metadata, descriptions, and release notes.

## Entries added

| Date | Entry | Source |
|---|---|---|
| 2024-12-08 | Tinsel Trader | [tinsel-trader](https://github.com/mrmartineau/tinsel-trader) |
| 2025-03-30 | my-api-tools | [my-api-tools](https://github.com/mrmartineau/my-api-tools) |
| 2026-02-04 | url-merge | [url-merge](https://github.com/mrmartineau/url-merge) |
| 2026-02-25 | vite-plugin-atlas | [vite-plugin-atlas](https://github.com/mrmartineau/vite-plugin-atlas) |
| 2026-02-26 | zed-surround | [zed-surround](https://github.com/mrmartineau/zed-surround) |
| 2026-02-27 | strifx | [strifx](https://github.com/mrmartineau/strifx) |
| 2026-03-11 | xtractr | [xtractr](https://github.com/mrmartineau/xtractr) |
| 2026-03-18 | ZUI (Zooey) | [zui](https://github.com/mrmartineau/zui) |
| 2026-04-27 | UK Primary School Maths | [uk-primary-school-maths](https://github.com/mrmartineau/uk-primary-school-maths) |
| 2026-05-06 | Otter web v1.0.0 | [Otter releases](https://github.com/mrmartineau/Otter/releases) |
| 2026-05-07 | zed-stack-starter | [zed-stack-starter](https://github.com/mrmartineau/zed-stack-starter) |
| 2026-06-03 | Reps | [reps.zander.wtf](https://github.com/mrmartineau/reps.zander.wtf) |

## Scope decisions

- **Curated highlights**, not exhaustive — trivial test/experiment repos were skipped.
- **Public repos only** — no private projects (e.g. Otter v3 rewrite, simmer) are referenced, since this is a public site.
- Dates use each project's repo creation date (or release date for Otter) as the "started/shipped around then" anchor.
- The `xtractr` entry ties back to the original 2023 Cloudflare scraper worklog entry for narrative continuity.

## Verification

- `pnpm check` passes with **0 errors** (pre-existing warnings in unrelated `color-hash` files only).
- All entries validate against the `worklog` content schema (`title` + `date`).

⚠️ Please skim for voice/accuracy before merging — these are summaries assembled from GitHub metadata, so feel free to tweak any wording that doesn't sound like you.

https://claude.ai/code/session_01EZZScP4BEXaj3S4PgNc82j

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZZScP4BEXaj3S4PgNc82j)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backfilled the worklog with 15 entries for public projects, releases, and three site milestones from Mar 2025–Jun 2026, restoring the timeline with accurate dates and links.

- **New Features**
  - Added entries for `my-api-tools`, `url-merge`, `vite-plugin-atlas`, `zed-surround`, `strifx`, `xtractr`, `ZUI`, UK Primary School Maths, Otter web v1.0.0, Otter web v1.1.0, `zed-stack-starter`, `Reps`, “Code notes come to the site”, “Add a projects page”, and “Launched lab.zander.wtf”.
  - Entries use repo creation or release dates and validate against the worklog schema.

- **Refactors**
  - Removed `Notes` and `Tools` links from the site footer.

<sup>Written for commit 21e2f1d04ede8a78838846fa2f499974f76db138. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mrmartineau/zander.wtf/pull/5?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

