### PR TITLE
Fix status button overflow on mobile

### DIFF
--- a/src/components/Status.astro
+++ b/src/components/Status.astro
@@ -17,9 +17,10 @@ import { ABOUT_ME, SHOW_STATUS } from 'src/consts';
   a {
     position: fixed;
     bottom: 1rem;
-    left: 50%;
-    transform: translateX(-50%);
-    right: 0;
+    left: 1rem;
+    right: 1rem;
+    width: fit-content;
+    margin-inline: auto;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -31,7 +32,6 @@ import { ABOUT_ME, SHOW_STATUS } from 'src/consts';
     font-size: var(--step--1);
     color: var(--bg);
     text-align: center;
-    max-width: fit-content;
     font-variation-settings:
       'wght' 400,
       'wdth' 100,
@@ -53,5 +53,11 @@ import { ABOUT_ME, SHOW_STATUS } from 'src/consts';
       'wdth' 125,
       'ital' 0;
     scale:1.05;
+  }
+
+  @media (max-width: 600px) {
+    a {
+      font-size: var(--step--2);
+    }
   }
 </style>


### PR DESCRIPTION
## Problem

The yellow "Available for work" status pill rendered as a text-overflowing circle on mobile. The cause was the positioning in `Status.astro`: `left: 50%` combined with `right: 0` capped the element's width at half the viewport, so on narrow screens the text wrapped into a tall stack and the `border-radius: 999px` turned the pill into a circle.

## Fix

- Anchor the button `1rem` from both viewport edges and centre it with `width: fit-content` + `margin-inline: auto`, so it can use the full viewport width (minus margins) before wrapping.
- Reduce the font size from `--step--1` to `--step--2` below 600px.

Desktop rendering is unchanged (still a centred pill sized to its content).

## Verification

Reproduced before/after in headless Chromium at a 390×844 viewport: the old CSS produces the broken circle, the new CSS renders a full-width pill on three lines. Also checked at 1280px — identical to the previous desktop layout. `pnpm biome check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012oeh42XHm1nb192X3vbGow

---
_Generated by [Claude Code](https://claude.ai/code/session_012oeh42XHm1nb192X3vbGow)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the mobile overflow that collapsed the yellow “Available for work” pill into a circle; desktop layout is unchanged. Anchors the pill 1rem from both edges, centers with `margin-inline: auto` and `width: fit-content`, and reduces font size below 600px for a clean wrap.

<sup>Written for commit c716b5c59dba56ed7f81e760f6752fcf5a384111. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mrmartineau/zander.wtf/pull/7?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

