### PR TITLE
Add Flora side project entry

### DIFF
--- a/src/content/projects/2026-08-11-flora.md
+++ b/src/content/projects/2026-08-11-flora.md
@@ -1,0 +1,35 @@
+---
+slug: flora
+title: Flora
+subtitle: Every plant and flower in our house and garden, written up — what it is, what it actually wants, and what needs doing to it before the frost.
+date: 2026-08-11
+repo: 'https://github.com/mrmartineau/flora.zander.wtf'
+link: 'https://flora.zander.wtf'
+# showReadme: true
+status: active
+tech: Astro, TypeScript, Cloudflare D1
+tags:
+  - astro
+  - typescript
+  - cloudflare
+  - css
+  - search
+  - gardening
+type: app
+---
+
+We kept forgetting things about our own garden. Which of these needs lifting before the first frost? Is this one drought-tolerant or is it the one that sulks the moment you look away? Someone would know the answer in July and nobody would know it in October.
+
+Flora is the answer written down. Every plant and flower in our house and garden gets its own page: habit, light, water, hardiness and position, a care section, a strip showing which months it's in flower, and the winter job if there is one. The RHS is the source of truth for the reference data — hardiness, flowering window, growing conditions — and the watering, feeding and pruning notes are how we actually look after the thing here.
+
+There's no database. Each plant is a single markdown file, and the frontmatter drives the whole UI, which means the same data can be read from several angles:
+
+- **`/`** — everything, grouped into outdoors and indoors, with whatever's in flower this month first
+- **`/in-flower`** — the flowering year. Pick a month, see what's out. Radio inputs, no JavaScript
+- **`/dry-spell`** — hot-weather triage: what to water first, and what to leave alone
+- **`/winter`** — winter jobs grouped by action (lift, move indoors, keep dry), most urgent first
+- **`/search`** — full-text search over every plant, on Cloudflare D1 via [astro-d1-search](/projects/astro-d1-search)
+
+Built with Astro and [ZUI](/projects/zui), deployed to Cloudflare Workers as a static site with two server-rendered routes for search.
+
+It ships with two agent skills. `add-plant` takes a photograph or just a name and does the whole job — identification with an honest confidence rating, a verified reference URL, the frontmatter, the body copy and the reindex — so adding a new plant is a sentence rather than an afternoon. `make-your-own-flora` turns a fork into somebody else's site: strip the plants, rebrand, point it at their own Cloudflare account, deploy. Search is optional, so if you don't want a Cloudflare account you can flip one flag and host the static output anywhere.


### PR DESCRIPTION
Adds `src/content/projects/2026-08-11-flora.md` — a project entry for [Flora](https://flora.zander.wtf), the site documenting the plants and flowers in the house and garden.

## Frontmatter

- `type: app`, `status: active`
- `repo` → https://github.com/mrmartineau/flora.zander.wtf, `link` → https://flora.zander.wtf
- `tech: Astro, TypeScript, Cloudflare D1`
- `showReadme` left commented out (matching the `reps` entry) — easy to flip on, but Flora's README is largely fork-and-deploy setup detail rather than a project overview
- `promote: false` (no `/images/promoted/flora.png` asset exists yet), so no `bgColour` / `image`

## Body

Written from Flora's README: the per-plant reference model, the four index pages that read the same markdown from different angles (`/in-flower`, `/dry-spell`, `/winter`, `/search`), and the two agent skills — `add-plant` for adding a plant from a photo or a name, and `make-your-own-flora` for turning a fork into someone else's site.

Cross-links to the existing `/projects/astro-d1-search` and `/projects/zui` entries, following the precedent set by the `otter-raycast` entry.

## Verification

`pnpm astro sync` completes cleanly, so the entry validates against the `projects` collection schema. A full `pnpm build` needs the external-API keys, which aren't available in this session.

Search index is not rebuilt here — CI reindexes after deploy.

---
_Generated by [Claude Code](https://claude.ai/code/session_018HWRmuB4eJjnNbD5oSUQsi)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `src/content/projects/2026-08-11-flora.md` to list Flora as a side project in the Projects collection. Includes site/repo links, `type: app`, `status: active`, `tech: Astro, TypeScript, Cloudflare D1`, and a brief body covering the per-plant model, index pages (`/in-flower`, `/dry-spell`, `/winter`, `/search`), and two agent skills (`add-plant`, `make-your-own-flora`).

<sup>Written for commit e2b2a205af44bde3f5fcd2224ed7e8e74c4c9b90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mrmartineau/zander.wtf/pull/8?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

